### PR TITLE
separate depth and printing

### DIFF
--- a/src/Tree.hs
+++ b/src/Tree.hs
@@ -1,24 +1,33 @@
 {-# LANGUAGE FlexibleInstances #-}
-module Tree (pretty, pretty', Tree(Leaf, Branch)) where
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+module Tree (pretty, pretty', Tree(Leaf, Branch), calculateDepth) where
 
-import Data.List.NonEmpty ( toList, NonEmpty )
+import Data.List.NonEmpty
 import Data.Text (Text(), pack)
 import Data.Foldable (fold)
 
-import Data.List(intercalate)
 
 data Tree a = Leaf a
    | Branch a (NonEmpty (Tree a))
-  deriving (Show, Eq)
+  deriving (Show, Eq, Functor, Foldable)
+
+newtype Depth = Depth { depthValue :: Int } deriving (Eq, Show)
+  deriving Num via Int
+
+calculateDepth :: Tree a -> Tree (a, Depth)
+calculateDepth = aux 0 where
+ aux n (Leaf a) = Leaf (a, n)
+ aux n (Branch a as) = Branch (a, n) (fmap (aux (n+1)) as)
 
 pretty :: CustomShow a => Tree a -> String
-pretty = aux 0 where 
- aux n (Leaf x) = customShowN n x
- aux n (Branch x y) = intercalate "\n" (customShowN n x :
-                                           toList (fmap (aux (n + 1)) y))
+pretty =  foldMap nodeToString . calculateDepth where
+   nodeToString :: CustomShow a => (a, Depth) -> String
+   nodeToString (a, d) = customShowN (depthValue d) a
 
 customShowN :: CustomShow a => Int -> a -> String
-customShowN n a = fold (replicate n separator <> pure (customShow a)) where 
+customShowN n a = fold (replicate n separator <> pure (customShow a)) where
  separator = "--"
 
 pretty' :: CustomShow a => Tree a -> Text


### PR DESCRIPTION
Refactor code to split the pretty printing from the labelling of the tree. THis is in preparation for:
* introduce State  monad 
* more complex labelling (eg, modified preordered tree traversal generation)

TODO:
* remove automatic derivation of functor and foldable type class instances (we can write them manually here, it's a good exercise; i autogenerate them just for saving time) 
* fix the foldMap, we want to fold the tree of strings with "\n" in our pretty printer (which is not the empty of the string monoid)